### PR TITLE
prevent duplicate output for -I | --head

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"strings"
@@ -97,6 +98,9 @@ func main() {
 		Out:     stderr,
 		Verbose: verbose,
 		Post:    input,
+	}
+	if (opts.Has("I") || opts.Has("head")) && terminal.IsTerminal(1) {
+		cmd.Stdout = ioutil.Discard
 	}
 	status := 0
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
A compromise solution for #2 - if the user is running `-I | --head` at the terminal, stdout is discarded to prevent the duplicate output; however if the user is piping or redirecting the output, stdout is preserved to maintain compatibility. 

I looked into rewriting `-I` into `-X HEAD` but curl behaves differently by waiting for content to be sent. [More info](https://serverfault.com/questions/140149/difference-between-curl-i-and-curl-x-head) I couldn't figure out a good workaround.. 