### PR TITLE
fix: Update cmd name in help.go

### DIFF
--- a/formatter/help.go
+++ b/formatter/help.go
@@ -12,7 +12,7 @@ type HelpAdapter struct {
 
 func (j HelpAdapter) Write(p []byte) (n int, err error) {
 	n = len(p)
-	cmd := "http"
+	cmd := "curlie"
 	if len(j.CmdName) == 0 {
 		cmd = j.CmdName
 	}


### PR DESCRIPTION
The current help text shows:

`Usage: http [options...] [METHOD] URL [REQUEST_ITEM [REQUEST_ITEM ...]]`
