### PR TITLE
 fix: use `curl -I` for HEAD request 

### DIFF
--- a/args/httpie.go
+++ b/args/httpie.go
@@ -23,8 +23,11 @@ func parseFancyArgs(args []string) (opts []string) {
 	}
 	method := strings.ToUpper(args[0])
 	switch method {
-	case "HEAD", "GET", "POST", "PUT", "DELETE":
+	case "GET", "POST", "PUT", "DELETE":
 		opts = append(opts, "-X", method)
+		args = args[1:]
+	case "HEAD":
+		opts = append(opts, "-I")
 		args = args[1:]
 	}
 	if len(args) == 0 {

--- a/args/parse_test.go
+++ b/args/parse_test.go
@@ -1,0 +1,40 @@
+package args
+
+import (
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	expected := []string{"http://example.com"}
+	parseAndCompare(t, []string{"curlie", "example.com"}, expected)
+}
+
+func TestParsePost(t *testing.T) {
+	expected := []string{"-X", "POST", "http://example.com"}
+	parseAndCompare(t, []string{"curlie", "post", "example.com"}, expected)
+}
+
+func TestParseHead(t *testing.T) {
+	expected := []string{"-I", "http://example.com"}
+	parseAndCompare(t, []string{"curlie", "head", "example.com"}, expected)
+}
+
+func parseAndCompare(t *testing.T, args, expected []string) {
+	opts := Parse(args)
+	if !compareStrings(opts, expected) {
+		t.Errorf("Expecting %v, but got %v for %v", expected, opts, args)
+	}
+
+}
+
+func compareStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if b[i] != v {
+			return false
+		}
+	}
+	return true
+}

--- a/main.go
+++ b/main.go
@@ -38,9 +38,13 @@ func main() {
 
 	// Change default method based on binary name.
 	switch os.Args[0] {
-	case "post", "put", "delete", "head":
+	case "post", "put", "delete":
 		if !opts.Has("X") && !opts.Has("request") {
 			opts = append(opts, "-X", os.Args[0])
+		}
+	case "head":
+		if !opts.Has("I") && !opts.Has("head") {
+			opts = append(opts, "-I")
 		}
 	}
 


### PR DESCRIPTION
Using `curl -X HEAD` results in the following warning:
> Warning: Setting custom HTTP method to HEAD with -X/--request may not work the
> Warning: way you want. Consider using -I/--head instead.