### PR TITLE
When using form params, transform values to form fields

### DIFF
--- a/args/httpie.go
+++ b/args/httpie.go
@@ -17,14 +17,14 @@ const (
 	jsonArg
 )
 
-type Postmode int
+type PostMode int
 
 const (
-	PostModeJSON Postmode = iota + 1
+	PostModeJSON PostMode = iota + 1
 	PostModeFORM
 )
 
-func parseFancyArgs(args []string, postMode Postmode) (opts Opts) {
+func parseFancyArgs(args []string, postMode PostMode) (opts Opts) {
 	if len(args) == 0 {
 		return
 	}

--- a/args/httpie.go
+++ b/args/httpie.go
@@ -17,7 +17,7 @@ const (
 	jsonArg
 )
 
-func parseFancyArgs(args []string) (opts []string) {
+func parseFancyArgs(args []string, isForm bool) (opts Opts) {
 	if len(args) == 0 {
 		return
 	}
@@ -43,7 +43,11 @@ func parseFancyArgs(args []string) (opts []string) {
 		case paramArg:
 			url = appendURLParam(url, name, value)
 		case fieldArg:
-			data[name] = value
+			if isForm {
+				opts = append(opts, "-F", name+"="+value)
+			} else {
+				data[name] = value
+			}
 		case jsonArg:
 			var v interface{}
 			json.Unmarshal([]byte(value), &v)

--- a/args/httpie.go
+++ b/args/httpie.go
@@ -17,7 +17,14 @@ const (
 	jsonArg
 )
 
-func parseFancyArgs(args []string, isForm bool) (opts Opts) {
+type Postmode int
+
+const (
+	JSON Postmode = iota + 1
+	FORM
+)
+
+func parseFancyArgs(args []string, postMode Postmode) (opts Opts) {
 	if len(args) == 0 {
 		return
 	}
@@ -43,7 +50,7 @@ func parseFancyArgs(args []string, isForm bool) (opts Opts) {
 		case paramArg:
 			url = appendURLParam(url, name, value)
 		case fieldArg:
-			if isForm {
+			if postMode == FORM {
 				opts = append(opts, "-F", name+"="+value)
 			} else {
 				data[name] = value

--- a/args/httpie.go
+++ b/args/httpie.go
@@ -20,8 +20,8 @@ const (
 type Postmode int
 
 const (
-	JSON Postmode = iota + 1
-	FORM
+	PostModeJSON Postmode = iota + 1
+	PostModeFORM
 )
 
 func parseFancyArgs(args []string, postMode Postmode) (opts Opts) {
@@ -50,7 +50,7 @@ func parseFancyArgs(args []string, postMode Postmode) (opts Opts) {
 		case paramArg:
 			url = appendURLParam(url, name, value)
 		case fieldArg:
-			if postMode == FORM {
+			if postMode == PostModeFORM {
 				opts = append(opts, "-F", name+"="+value)
 			} else {
 				data[name] = value

--- a/args/parse.go
+++ b/args/parse.go
@@ -113,7 +113,11 @@ func Parse(argv Opts) (opts Opts) {
 		}
 	}
 	if len(args) > 0 {
-		opts = append(opts, parseFancyArgs(args, isForm)...)
+		postMode := JSON
+		if isForm {
+			postMode = FORM
+		}
+		opts = append(opts, parseFancyArgs(args, postMode)...)
 	}
 	return
 }

--- a/args/parse.go
+++ b/args/parse.go
@@ -113,9 +113,9 @@ func Parse(argv Opts) (opts Opts) {
 		}
 	}
 	if len(args) > 0 {
-		postMode := JSON
+		postMode := PostModeJSON
 		if isForm {
-			postMode = FORM
+			postMode = PostModeFORM
 		}
 		opts = append(opts, parseFancyArgs(args, postMode)...)
 	}

--- a/args/parse.go
+++ b/args/parse.go
@@ -66,7 +66,12 @@ func (opts *Opts) Remove(opt string) bool {
 }
 
 // Parse converts an HTTPie like argv into a list of curl options.
-func Parse(argv []string) (opts Opts) {
+func Parse(argv Opts) (opts Opts) {
+	isForm := argv.Has("F") || argv.Has("form")
+	if isForm {
+		argv.Remove("F")
+		argv.Remove("form")
+	}
 	args := []string{}
 	sort.Strings(curlLongValues)
 	more := true
@@ -108,7 +113,7 @@ func Parse(argv []string) (opts Opts) {
 		}
 	}
 	if len(args) > 0 {
-		opts = append(opts, parseFancyArgs(args)...)
+		opts = append(opts, parseFancyArgs(args, isForm)...)
 	}
 	return
 }

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	if opts.Has("h") || opts.Has("help") {
 		stdout = &formatter.HelpAdapter{Out: stdout, CmdName: os.Args[0]}
 	} else {
+		isForm := opts.Has("F")
 		if pretty || terminal.IsTerminal(1) {
 			inputWriter = &formatter.JSON{
 				Out:    inputWriter,
@@ -88,7 +89,7 @@ func main() {
 			hasInput = false
 		}
 		if hasInput {
-			if !headerSupplied(opts, "Content-Type") {
+			if !headerSupplied(opts, "Content-Type") && !isForm {
 				opts = append(opts, "-H", "Content-Type: application/json")
 			}
 		}


### PR DESCRIPTION
Httpie is smart enough to transform requests with the --form flag into actual form requests. Instead of parsing their arguments as JSON, they parse them as form fields. This commit enables the same thing for curlie

Note: This is my first time using Go in any capacity and my mastery of `curl` is pretty lacking, so feel free to cancel this in favor of some other approach. I'm also open to any feedback 