### PR TITLE
Use basic colors

### DIFF
--- a/formatter/color.go
+++ b/formatter/color.go
@@ -32,7 +32,7 @@ const (
 func (cs ColorScheme) Color(name ColorName) string {
 	switch name {
 	case ResetColor:
-		return "\x1b[39m"
+		return "\x1b[0m"
 	case DefaultColor:
 		return cs.Default
 	case CommentColor:
@@ -56,13 +56,13 @@ func (cs ColorScheme) IsZero() bool {
 }
 
 var DefaultColorScheme = ColorScheme{
-	Default: "\x1b[38;5;245m",
-	Comment: "\x1b[38;5;237m",
-	Status:  "\x1b[38;5;136m",
-	Field:   "\x1b[38;5;33m",
-	Value:   "\x1b[38;5;37m",
-	Literal: "\x1b[38;5;166m",
-	Error:   "\x1b[38;5;1m",
+	Default: "\x1b[37m",
+	Comment: "\x1b[90m",
+	Status:  "\x1b[33m",
+	Field:   "\x1b[34m",
+	Value:   "\x1b[36m",
+	Literal: "\x1b[35m",
+	Error:   "\x1b[31m",
 }
 
 type HeaderColorizer struct {


### PR DESCRIPTION
Use the basic ANSI colors to help readability by respecting the user's terminal theme. This is consistent with the behavior of HTTPie and many other terminal applications.

The existing color scheme may not be readable with certain terminal themes. Consider this command: `curlie --http1.1 -v https://httpbin.org/anything` 

Left = current curlie colors
Right = colors in this PR

**[Grayscale](https://github.com/chriskempson/base16-shell/blob/master/scripts/base16-grayscale-dark.sh)**
![greyscale](https://user-images.githubusercontent.com/6550543/77588360-10a13d00-6ec0-11ea-865c-5afb8cc6bb76.png)

**[Nord](https://github.com/chriskempson/base16-shell/blob/master/scripts/base16-nord.sh)**
![nord](https://user-images.githubusercontent.com/6550543/77588362-10a13d00-6ec0-11ea-8c08-c96803b4acac.png)

**[Zenburn](https://github.com/chriskempson/base16-shell/blob/master/scripts/base16-zenburn.sh)**
![zenburn](https://user-images.githubusercontent.com/6550543/77588364-1139d380-6ec0-11ea-9014-6a5ccd996fc9.png)



