### PR TITLE
Reset terminal colors after parses a JSON

### DIFF
--- a/formatter/json.go
+++ b/formatter/json.go
@@ -77,7 +77,7 @@ func (j *JSON) Write(p []byte) (n int, err error) {
 			cp = append(append(append(append(cp, '\n'), bytes.Repeat(indent, j.level)...), cs.Default...), b)
 			if b == '}' && j.level == 0 {
 				// Add a return after the outer closing brace.
-				cp = append(cp, '\n')
+				cp = append(append(cp, '\n'), cs.Color(ResetColor)...)
 			}
 		case ':':
 			j.isValue = true

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/akamensky/argparse v0.0.0-20180518035907-99676ba18cd5/go.mod h1:pdh+2piXurh466J9tqIqq39/9GO2Y8nZt6Cxzu18T9A=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+golang.org/x/crypto v0.0.0-20180524125353-159ae71589f3 h1:mPCVkWhSH1DSDQg4ZwAFYMo/+evpqK1WzBt33b9TXRE=
 golang.org/x/crypto v0.0.0-20180524125353-159ae71589f3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/sys v0.0.0-20180525062015-31355384c89b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=


### PR DESCRIPTION
Now curlie reset the terminal colors after parsing a JSON response.

Fixes #20 