### PR TITLE
workaround for Windows Stdin bug #12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,8 @@
 module github.com/rs/curlie
 
 require (
-	github.com/akamensky/argparse v0.0.0-20180518035907-99676ba18cd5 // indirect
-	github.com/jessevdk/go-flags v1.4.0 // indirect
-	golang.org/x/crypto v0.0.0-20180524125353-159ae71589f3
-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
+	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037
 )
 
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/rs/curlie
 
 require (
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a
-	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037
+	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,9 @@
-github.com/akamensky/argparse v0.0.0-20180518035907-99676ba18cd5/go.mod h1:pdh+2piXurh466J9tqIqq39/9GO2Y8nZt6Cxzu18T9A=
-github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-golang.org/x/crypto v0.0.0-20180524125353-159ae71589f3 h1:mPCVkWhSH1DSDQg4ZwAFYMo/+evpqK1WzBt33b9TXRE=
-golang.org/x/crypto v0.0.0-20180524125353-159ae71589f3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/sys v0.0.0-20180525062015-31355384c89b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a h1:vclmkQCjlDX5OydZ9wv8rBCcS0QyQY66Mpf/7BZbInM=
+golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 h1:YyJpGZS1sBuBCzLAR1VEpK193GlqGZbnPFnPV/5Rsb4=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/rs/curlie/args"
 	"github.com/rs/curlie/formatter"
-	"golang.org/x/crypto/ssh/terminal"
+	"github.com/rs/curlie/terminal"
 )
 
 func main() {

--- a/terminal/util.go
+++ b/terminal/util.go
@@ -1,0 +1,12 @@
+// +build !windows
+
+package terminal
+
+import (
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+// IsTerminal returns whether the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	return terminal.IsTerminal(fd)
+}

--- a/terminal/util_windows.go
+++ b/terminal/util_windows.go
@@ -15,20 +15,17 @@
 // See https://stackoverflow.com/a/38612652/151312
 package terminal
 
-import (
-	"golang.org/x/sys/windows"
-)
-
 var fdStdin = 0
 
 // IsTerminal returns whether the given file descriptor is a terminal.
 func IsTerminal(fd int) bool {
-	if fdStdin == fd {
-		// This is a hack. See the note above to help fix this.
-		return true
-	}
-
-	var st uint32
-	err := windows.GetConsoleMode(windows.Handle(fd), &st)
-	return err == nil
+	// Neither cmd.exe nor Windows Terminal 1.0 are detected as a
+	// Terminal through the proper means. However, Windows Terminal
+	// seems to remove formatting to Stdout when redirecting to a file.
+	/*
+		var st uint32
+		err := windows.GetConsoleMode(windows.Handle(fd), &st)
+		return err == nil
+	*/
+	return true
 }

--- a/terminal/util_windows.go
+++ b/terminal/util_windows.go
@@ -1,0 +1,34 @@
+// +build windows
+
+// Package terminal provides an alternate version Go's IsTerminal,
+// as a workaround for https://github.com/rs/curlie/issues/12
+//
+// On Windows the very act of checking Stdin causes Stdin to open.
+// Since we may need Stdin, it is best to not check it and just
+// assume that the user is expecting pretty output, or will disable
+// it, or will use curl.exe.
+//
+// TODO However, there may be a better solution:
+//   1. Check if Stdin is open (or will be opened by curl/curlie)
+//   2. Check IsTerminal(0) (already knowing the open/close state)
+//   3. Stdin.Close(), unless it was open, or will be opened
+// See https://stackoverflow.com/a/38612652/151312
+package terminal
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+var fdStdin = 0
+
+// IsTerminal returns whether the given file descriptor is a terminal.
+func IsTerminal(fd int) bool {
+	if fdStdin == fd {
+		// This is a hack. See the note above to help fix this.
+		return true
+	}
+
+	var st uint32
+	err := windows.GetConsoleMode(windows.Handle(fd), &st)
+	return err == nil
+}


### PR DESCRIPTION
Re: #12

The very act of checking the status of `os.Stdin` (`terminal.IsTerminal(0)`) seems to cause it to open, and thus cause `curlie` to hang on Windows.

Furthermore, neither cmd.exe nor Windows Terminal 1.0 are detected as Terminals.

This patch will cause the `IsTerminal(0)` check to always return true on Windows, assuming that the reason the user has chosen curlie is to get the benefit of color and such (otherwise the check will always return false and it will behave as curl).

There may be a better solution, but this is a definite improvement over the current non-working behavior.

Manually tested on MacOS and Windows 10 to be reasonably sure that no bugs were introduced.

Tested on MacOS:

```bash
curlie https://example.com              # colored output, as expected
curlie https://example.com | less       # colored output, as expected
curlie https://example.com > foo.html   # plain output, as expected
```

Tested on Windows 10:

```bash
curlie https://example.com             # colored output in Windows Terminal
curlie https://example.com | more      # colored output, as expected
curlie https://example.com > foo.html  # plain output, as expected
```

Note: cmd.exe cannot handle colors and outputs junk instead.