### PR TITLE
Re: #22 add version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,20 @@ Custom method, headers and JSON data:
 
 ![](doc/put.png)
 
+## Build
+
+Build with `goreleaser` to test that all platforms compile properly.
+
+```bash
+goreleaser --snapshot --skip-publish --rm-dist
+```
+
+Or with `go build` for your current platform only.
+
+```bash
+go build .
+```
+
 ## Differences with httpie
 
 * Like `curl` but unlike `httpie`, headers are written on `stderr` instead of `stdout`.

--- a/main.go
+++ b/main.go
@@ -15,7 +15,20 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 )
 
+var (
+	commit  = "0000000"
+	version = "v0.0.0-LOCAL"
+	date    = "0000-00-00T00:00:00Z"
+)
+
 func main() {
+	// handle `curlie version` separately from `curl --version`
+	if 2 == len(os.Args) && "version" == os.Args[1] {
+		fmt.Printf("curlie %s (%s)\n", version, date)
+		os.Exit(0)
+		return
+	}
+
 	// *nixes use 0, 1, 2
 	// Windows uses random numbers
 	stdinFd := int(os.Stdin.Fd())


### PR DESCRIPTION
- Add version from git tags (must be built with `go generate ./...`).
    ```bash
    curlie version
    ```
    ```txt
    curlie v1.4.1-pre0+dirty (2020-09-12T02:46:46-06:00)
    ```
- Do not generate Linux-specific `args.go` on darwin.
- Ignore `xversion.go` (so that clean tags will produce clean output)