### PR TITLE
Add install variant via MacPorts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Using [homebrew](https://brew.sh/):
 brew install rs/tap/curlie
 ```
 
+Using [macports](https://www.macports.org):
+
+```
+sudo port install curlie
+```
+
 Using [pkg](https://man.freebsd.org/pkg/8):
 
 ```


### PR DESCRIPTION
Hi @rs 👋. I'm a maintainer of the [curlie](https://ports.macports.org/port/curlie) port over at MacPorts. I've added the install variant via MacPorts to the README. Thank you for maintaining this amazing project.