### PR TITLE
Add install alternative via Scoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ Using [go](https://golang.org/):
 go install github.com/rs/curlie@latest
 ```
 
+Using [scoop](https://scoop.sh/):
+
+```
+scoop install curlie
+```
+
 Or download a [binary package](https://github.com/rs/curlie/releases/latest).
 
 ## Usage


### PR DESCRIPTION
Add installation option via Scoop for Windows (added as ScoopInstaller/Main#3170).