### PR TITLE
Document --pretty

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Custom method, headers and JSON data:
 
 ![](doc/put.png)
 
+When running interactively, `curlie` provides pretty-printed output for json. To force pretty-printed output, pass `--pretty`.
+
 ## Build
 
 Build with [goreleaser](https://goreleaser.com) to test that all platforms compile properly.


### PR DESCRIPTION
For many tools I desire behavior like `less`'s `--quit-if-one-screen`. So, if output fills more than one screen, page it and don't spam my terminal with gobs of output.

However, piping to `less` often turns off many tools' automatic colorized output. Accordingly, many tools support flags to force colorized output. So, I have a small [autopager script](https://github.com/kbd/setup/blob/master/HOME/bin/autopager) that I configure for a bunch of tools as follows:

```
alias http='autopager http --pretty=all'
alias https='autopager https --pretty=all'
alias jq='autopager jq -C'
alias curl='autopager curl "" -L'
alias curlie='autopager curlie --pretty -L'
alias xh='autopager xh --pretty=all'
alias yq='autopager yq -C'
```

I had to read `curlie`'s source to (happily) discover that `curlie` supports the same pattern. This PR documents the flag.