### PR TITLE
Update install method for Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you like the interface of [HTTPie](https://httpie.org) but miss the features 
 Using [homebrew](https://brew.sh/):
 
 ```sh
-brew install rs/tap/curlie
+brew install curlie
 ```
 
 Using [webi](https://webinstall.dev/curlie/):


### PR DESCRIPTION
Someone contributed [a formula for curlie](https://github.com/Homebrew/homebrew-core/blob/master/Formula/curlie.rb), so no need for manually tapping anymore.