### PR TITLE
Revert "fix headers/body order (#55)"

### DIFF
--- a/formatter/cleanup.go
+++ b/formatter/cleanup.go
@@ -16,8 +16,6 @@ type HeaderCleaner struct {
 	// Post is inserted after the request headers.
 	Post *bytes.Buffer
 
-	HeadersDone chan<- struct{}
-
 	buf  []byte
 	line []byte
 }
@@ -31,8 +29,6 @@ func (c *HeaderCleaner) Write(p []byte) (n int, err error) {
 	n = len(p)
 	cp := c.buf
 	p = bytes.Replace(p, capath, ccapath, 1) // Fix curl misformatted line
-
-	closeAfterWrite := false
 	for len(p) > 0 {
 		idx := bytes.IndexByte(p, '\n')
 		if idx == -1 {
@@ -52,9 +48,6 @@ func (c *HeaderCleaner) Write(p []byte) (n int, err error) {
 			}
 		case '<':
 			c.line = c.line[i+2:]
-			if bytes.Equal(c.line, []byte("\r\n")) && c.HeadersDone != nil {
-				closeAfterWrite = true
-			}
 		case '}', '{':
 			ignore = true
 			if c.Verbose && c.Post != nil {
@@ -69,13 +62,9 @@ func (c *HeaderCleaner) Write(p []byte) (n int, err error) {
 		if !ignore {
 			cp = append(cp, c.line...)
 		}
-
 		c.line = c.line[:0]
 	}
 	_, err = c.Out.Write(cp)
-	if closeAfterWrite {
-		close(c.HeadersDone)
-	}
 	return
 }
 

--- a/main.go
+++ b/main.go
@@ -138,28 +138,14 @@ func main() {
 		fmt.Println()
 		return
 	}
-
 	cmd := exec.Command("curl", opts...)
 	cmd.Stdin = stdin
 	cmd.Stdout = stdout
-
-	tmpOut := &formatter.HeaderCleaner{
+	cmd.Stderr = &formatter.HeaderCleaner{
 		Out:     stderr,
 		Verbose: verbose,
 		Post:    input,
 	}
-
-	if terminal.IsTerminal(stdoutFd) && terminal.IsTerminal(stderrFd) && !quiet {
-		headerBlock := make(chan struct{})
-		cmd.Stdout = &blockedWrite{
-			ch:  headerBlock,
-			out: stdout,
-		}
-		tmpOut.HeadersDone = headerBlock
-	}
-
-	cmd.Stderr = tmpOut
-
 	if (opts.Has("I") || opts.Has("head")) && terminal.IsTerminal(stdoutFd) {
 		cmd.Stdout = ioutil.Discard
 	}
@@ -188,14 +174,4 @@ func headerSupplied(opts args.Opts, header string) bool {
 		}
 	}
 	return false
-}
-
-type blockedWrite struct {
-	ch  <-chan struct{}
-	out io.Writer
-}
-
-func (c *blockedWrite) Write(p []byte) (n int, err error) {
-	<-c.ch
-	return c.out.Write(p)
 }


### PR DESCRIPTION
This reverts #55.

The pull request above introduced sane-ordering to the terminal output by prioritizing headers first and then the response body. But unfortunately it introduces a deadlock in cases where we have no headers to print.

Simple commands like `curlie` or `curlie -h` will hang.

Sometimes it also causes the program to deadlock even when headers are present. It probably has something to do with the code failing to properly detect where the headers' section ends. But I'm having difficulty reliably reproducing this case.

Fixes #72 
Fixes #73 