### PR TITLE
Update Go version and GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,26 +8,23 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
-        uses: actions/setup-go@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.17
-      -
-        name: Test
+          go-version: stable
+
+      - name: Test
         run: go test ./...
-      -
-        name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v2
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          distribution: goreleaser
           version: latest
-          args: release --clean
+          args: ${{ github.ref_type == 'tag' && 'release' || 'build --snapshot' }} --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,7 +1,7 @@
+version: 2
 project_name: curlie
 builds:
-  -
-    binary: curlie
+  - binary: curlie
     env:
       - CGO_ENABLED=0
     goos:
@@ -14,14 +14,12 @@ builds:
       - arm
       - arm64
     ignore:
-      -
-        goos: windows
+      - goos: windows
         goarch: arm64
 release:
   name_template: "{{.ProjectName}}-v{{.Version}}"
 brews:
-  -
-    tap:
+  - repository:
       owner: rs
       name: homebrew-tap
     commit_author:
@@ -30,8 +28,7 @@ brews:
     homepage: https://github.com/rs/curlie
     description: The power of curl, the ease of use of httpie.
 nfpms:
-  -
-    maintainer: Olivier Poitrey <rs@rhapsodyk.net>
+  - maintainer: Olivier Poitrey <rs@rhapsodyk.net>
     description: curle is a frontend to curl that offers the ease of use of httpie without having to compromise curl features and performance.
     license: MIT
     formats:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/rs/curlie
 
-require (
-	golang.org/x/sys v0.15.0
-	golang.org/x/term v0.15.0
-)
+go 1.24.0
 
-go 1.13
+require (
+	golang.org/x/sys v0.30.0
+	golang.org/x/term v0.29.0
+)

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
-golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
-golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.29.0 h1:L6pJp37ocefwRRtYPKSWOWzOtWSxVajvz2ldH/xi3iU=
+golang.org/x/term v0.29.0/go.mod h1:6bl4lRlvVuDgSf3179VpIxBF0o10JUpXWOnI7nErv7s=


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow, the GoReleaser configuration, and the Go module dependencies. The changes aim to modernize the dependencies and streamline the release process.

Updates to GitHub Actions workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L11-L33): Updated `actions/checkout` to v4, `actions/setup-go` to v5, and `goreleaser/goreleaser-action` to v6. Also modified the `args` for the GoReleaser step to conditionally run `release` or `build --snapshot` based on the GitHub reference type.

Changes to GoReleaser configuration:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R1-R4): Updated the version to 2 and refactored the configuration to remove unnecessary dashes and align the format. [[1]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R1-R4) [[2]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L17-R22) [[3]](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689L33-R31)

Updates to Go module dependencies:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R3-L8): Updated Go version to 1.24.0 and upgraded `golang.org/x/sys` to v0.30.0 and `golang.org/x/term` to v0.29.0.