### PR TITLE
Fix proxy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,17 @@ Or download a [binary package](https://github.com/rs/curlie/releases/latest).
 
 Synopsis:
 
-    $ curlie [CURL_OPTIONS...] [METHOD] URL [ITEM [ITEM]]
+```sh
+curlie [CURL_OPTIONS...] [METHOD] URL [ITEM [ITEM]]
+```
 
 Simple GET:
 
-![](doc/get.png)
+![Simple GET request example](doc/get.png)
 
 Custom method, headers and JSON data:
 
-![](doc/put.png)
+![Custom PUT request with headers and JSON data example](doc/put.png)
 
 When running interactively, `curlie` provides pretty-printed output for json. To force pretty-printed output, pass `--pretty`.
 
@@ -77,13 +79,13 @@ When running interactively, `curlie` provides pretty-printed output for json. To
 Build with [goreleaser](https://goreleaser.com) to test that all platforms compile properly.
 
 ```sh
-goreleaser --snapshot --skip-publish --rm-dist
+goreleaser build --clean --snapshot
 ```
 
-Or with `go build` for your current platform only.
+Or for your current platform only.
 
 ```sh
-go build .
+goreleaser build --clean --snapshot --single-target
 ```
 
 ## Differences with httpie

--- a/args/curlopts.go
+++ b/args/curlopts.go
@@ -1,5 +1,7 @@
 package args
 
+import "sort"
+
 var (
 	curlShortValues = "EKCbcdDFPHhmoUQreXYytzTuAw"
 	curlLongValues  = []string{
@@ -77,6 +79,7 @@ var (
 		"proto",
 		"proto-default",
 		"proto-redir",
+		"proxy",
 		"proxy-cacert",
 		"proxy-capath",
 		"proxy-cert",
@@ -133,5 +136,10 @@ var (
 		"url-query",
 		"user",
 		"user-agent",
-		"write-out"}
+		"write-out",
+	}
 )
+
+func init() {
+	sort.Strings(curlLongValues)
+}


### PR DESCRIPTION
Added support for `--proxy`

* [`args/curlopts.go`](diffhunk://#diff-0bcbcee2d3308d68f3dfeca31935c7aaf3565fc301c33721d97a5cb2dd5d0d39R82): Added the `proxy` option to the `curlLongValues` list.
* [`args/curlopts.go`](diffhunk://#diff-0bcbcee2d3308d68f3dfeca31935c7aaf3565fc301c33721d97a5cb2dd5d0d39L136-R145): Implemented sorting of `curlLongValues` in the `init` function to ensure options are always in order since `sort.SearchStrings` expects a sorted slice.

Closes #31 