### PR TITLE
Add more platforms, SBOMs and sign artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,27 @@ name: goreleaser
 
 on:
   pull_request:
+    branches:
+      - master
   push:
+    branches:
+      - master
+    tags:
+      - "*"
+
+concurrency:
+  group: ${{ github.ref_name }}-goreleaser
+  cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,6 +36,10 @@ jobs:
 
       - name: Test
         run: go test ./...
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3
+        if: github.ref_type == 'tag'
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,14 +10,41 @@ builds:
       - freebsd
       - windows
     goarch:
+      - 386
       - amd64
       - arm
       - arm64
-    ignore:
+      - ppc64le
+      - s390x
+    goarm:
+      - 6
+      - 7
+
+archives:
+  - format_overrides:
       - goos: windows
-        goarch: arm64
+        formats: ['zip']
+
+sboms:
+  - artifacts: archive
+    documents:
+      - "${artifact}.spdx.json"
+
 release:
   name_template: "{{.ProjectName}}-v{{.Version}}"
+
+signs:
+  - cmd: cosign
+    artifacts: checksum
+    output: true
+    certificate: "${artifact}.pem"
+    args:
+      - sign-blob
+      - "--output-signature=${signature}"
+      - "--output-certificate=${certificate}"
+      - "${artifact}"
+      - "--yes"
+
 brews:
   - repository:
       owner: rs
@@ -27,6 +54,7 @@ brews:
       email: rs@rhapsodyk.net
     homepage: https://github.com/rs/curlie
     description: The power of curl, the ease of use of httpie.
+
 nfpms:
   - maintainer: Olivier Poitrey <rs@rhapsodyk.net>
     description: curle is a frontend to curl that offers the ease of use of httpie without having to compromise curl features and performance.


### PR DESCRIPTION
This pull request includes significant changes to the GitHub Actions workflow for releases and updates to the GoReleaser configuration. The most important changes include specifying branches and tags for triggering workflows, adding concurrency control, setting permissions, and updating the GoReleaser configuration to include additional architectures and signing artifacts.

Updates to GitHub Actions workflow:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R5-R25): Specified branches and tags to trigger workflows, added concurrency control, and set read and write permissions for contents and id-token.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R40-R43): Added a step to install Cosign if the reference type is a tag.

Updates to GoReleaser configuration:

* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R13-R47): Added support for `386`, `ppc64le`, and `s390x` architectures, specified `goarm` versions, and defined format overrides for Windows archives.
* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R13-R47): Added SBOMs (Software Bill of Materials) generation for archives.
* [`.goreleaser.yml`](diffhunk://#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689R13-R47): Added artifact signing using Cosign.

Closes #54 
Closes #42 (technically already implemented, but at least we can close the issue)